### PR TITLE
[HHH - 44] CreateCampaign page 리팩토링 

### DIFF
--- a/src/components/CampaignForm/index.jsx
+++ b/src/components/CampaignForm/index.jsx
@@ -11,7 +11,14 @@ import Modal from '../Modal';
 import AdPreview from '../AdPreview';
 import { campaignCountries } from '../../constants';
 
-export default function CampaignForm({ estimate, imageUrl, onImageUpload, onFormSubmit, onCountrySelect, setMinAge, setMaxAge, setGender, setDailyBudget, dailyBudget }) {
+export default function CampaignForm({
+  estimate,
+  imageUrl,
+  targetData,
+  setTargetData,
+  onImageUpload,
+  onFormSubmit,
+}) {
   const [isAdPreview, setIsAdPreview] = useState(false);
   const {
     register,
@@ -104,8 +111,11 @@ export default function CampaignForm({ estimate, imageUrl, onImageUpload, onForm
                         min="18"
                         max="65"
                         name={name}
-                        onChange={(e) => {
-                          setMinAge(e.target.value);
+                        onChange={(event) => {
+                          setTargetData({
+                            ...targetData,
+                            minAge: event.target.value,
+                          });
                         }}
                       />
                     )}
@@ -121,8 +131,11 @@ export default function CampaignForm({ estimate, imageUrl, onImageUpload, onForm
                         min="18"
                         max="65"
                         name={name}
-                        onChange={(e) => {
-                          setMaxAge(e.target.value);
+                        onChange={(event) => {
+                          setTargetData({
+                            ...targetData,
+                            maxAge: event.target.value,
+                          });
                         }}
                       />
                     )}
@@ -137,8 +150,11 @@ export default function CampaignForm({ estimate, imageUrl, onImageUpload, onForm
                     render={({ onChange, name }) => (
                       <S.TargetGenderAndCountrySelect
                         name={name}
-                        onChange={(e) => {
-                          setGender(e.target.value);
+                        onChange={(event) => {
+                          setTargetData({
+                            ...targetData,
+                            gender: event.target.value,
+                          });
                         }}
                       >
                         <option value='male'>남성</option>
@@ -152,7 +168,12 @@ export default function CampaignForm({ estimate, imageUrl, onImageUpload, onForm
                   <S.Label>국가</S.Label>
                   <S.ReactSelectWrapper>
                     <Select
-                      onChange={onCountrySelect}
+                      onChange={(selectedOption) => {
+                        setTargetData({
+                          ...targetData,
+                          country: selectedOption,
+                        });
+                      }}
                       options={campaignCountries}
                       isMulti
                     />
@@ -186,7 +207,7 @@ export default function CampaignForm({ estimate, imageUrl, onImageUpload, onForm
                 </Card>
                 <Card title='일일 예산'>
                   <S.SliderWrapper>
-                    <S.SliderPrice>{(dailyBudget * 1).toLocaleString()} 원</S.SliderPrice>
+                    <S.SliderPrice>{(targetData.dailyBudget * 1).toLocaleString()} 원</S.SliderPrice>
                     <Controller
                       control={control}
                       name="dailyBudget"
@@ -197,8 +218,11 @@ export default function CampaignForm({ estimate, imageUrl, onImageUpload, onForm
                           max="200000"
                           step="5000"
                           name={name}
-                          onChange={(e) => {
-                            setDailyBudget(e.target.value);
+                          onChange={(event) => {
+                            setTargetData({
+                              ...targetData,
+                              dailyBudget: event.target.value,
+                            });
                           }}
                         />
                       )}
@@ -224,13 +248,13 @@ export default function CampaignForm({ estimate, imageUrl, onImageUpload, onForm
                   <S.DailyEstimateResultsContainer>
                     <S.DailyEstimateReachAndClick>도달</S.DailyEstimateReachAndClick>
                     <S.DailyEstimateResults>
-                      {estimate.cpm ? `${(Math.floor(dailyBudget / estimate.cpm * 1000 * 0.95)).toLocaleString()} ~ ${(Math.floor(dailyBudget / estimate.cpm * 1000 * 1.05)).toLocaleString()}명` : '타겟을 설정하세요'}
+                      {estimate.cpm ? `${(Math.floor(targetData.dailyBudget / estimate.cpm * 1000 * 0.95)).toLocaleString()} ~ ${(Math.floor(targetData.dailyBudget / estimate.cpm * 1000 * 1.05)).toLocaleString()}명` : '타겟을 설정하세요'}
                     </S.DailyEstimateResults>
                   </S.DailyEstimateResultsContainer>
                   <S.DailyEstimateResultsContainer>
                     <S.DailyEstimateReachAndClick>링크 클릭</S.DailyEstimateReachAndClick>
                     <S.DailyEstimateResults>
-                      {estimate.cpm ? `${(Math.floor(dailyBudget / estimate.cpc * 0.95)).toLocaleString()} ~ ${(Math.floor(dailyBudget / estimate.cpc * 1.05)).toLocaleString()}명` : '타겟을 설정하세요'}
+                      {estimate.cpm ? `${(Math.floor(targetData.dailyBudget / estimate.cpc * 0.95)).toLocaleString()} ~ ${(Math.floor(targetData.dailyBudget / estimate.cpc * 1.05)).toLocaleString()}명` : '타겟을 설정하세요'}
                     </S.DailyEstimateResults>
                   </S.DailyEstimateResultsContainer>
                 </S.DailyEstimateResultsWrapper>
@@ -242,9 +266,9 @@ export default function CampaignForm({ estimate, imageUrl, onImageUpload, onForm
                 <S.PaymentAmountContainer>
                   <S.PaymentAmountDescription>
                     <S.PaymentAmountText>총 결제금액</S.PaymentAmountText>
-                    <S.PaymentAmountSubText>일일 {(dailyBudget * 1).toLocaleString()}원X{campaignDuration}일</S.PaymentAmountSubText>
+                    <S.PaymentAmountSubText>일일 {(targetData.dailyBudget * 1).toLocaleString()}원X{campaignDuration}일</S.PaymentAmountSubText>
                   </S.PaymentAmountDescription>
-                  <S.TotalPaymentAmout>{(dailyBudget * campaignDuration).toLocaleString()} 원</S.TotalPaymentAmout>
+                  <S.TotalPaymentAmout>{(targetData.dailyBudget * campaignDuration).toLocaleString()} 원</S.TotalPaymentAmout>
                 </S.PaymentAmountContainer>
               </S.Estimate>
               <S.ButtonWrapper>
@@ -270,7 +294,10 @@ export default function CampaignForm({ estimate, imageUrl, onImageUpload, onForm
 }
 
 CampaignForm.propTypes = {
+  estimate: PropTypes.object.isRequired,
   imageUrl: PropTypes.string.isRequired,
+  targetData: PropTypes.object.isRequired,
+  setTargetData: PropTypes.func.isRequired,
   onImageUpload: PropTypes.func.isRequired,
   onFormSubmit: PropTypes.func.isRequired,
 };

--- a/src/constants/message.js
+++ b/src/constants/message.js
@@ -1,0 +1,18 @@
+export const registerMessage = Object.freeze({
+  SIGN_UP_FAILED: '회원가입에 실패했습니다.',
+});
+
+export const campaignMessage = Object.freeze({
+  CAMPAIGN_CREATION_FAILED: '캠페인 생성에 실패했습니다.',
+});
+
+export const imageUploadMessage = Object.freeze({
+  FILE_NOT_EXIST: '파일이 존재하지 않습니다.',
+  MAXIMIM_FILE_SIZE_EXCEEDED: '파일이 최대 크기(1MB)를 초과하였습니다.',
+  FILE_UPLOAD_FAILED: '파일 업로드에 실패하였습니다.',
+});
+
+export const paymentMessage = Object.freeze({
+  PAYMENT_FAILED: '결제에 실패했습니다.',
+  PAYMENT_SUCCESS: '결제가 완료되었습니다.',
+});

--- a/src/pages/CreateCampaign/index.jsx
+++ b/src/pages/CreateCampaign/index.jsx
@@ -14,22 +14,19 @@ import { fetchNewCampaign } from '../../apis/campaigns';
 
 export default function CreateCampaign() {
   const [url, setUrl] = useState('');
-  const [selectedCountry, setSelectedCountry] = useState(null);
-  const [minAge, setMinAge] = useState(null);
-  const [maxAge, setMaxAge] = useState(null);
-  const [gender, setGender] = useState('male');
-  const [dailyBudget, setDailyBudget] = useState(5000);
+  const [targetData, setTargetData] = useState({
+    minAge: null,
+    maxAge: null,
+    gender: 'male',
+    country: null,
+    dailyBudget: '5000',
+  });
   const dispatch = useDispatch();
   const user = useSelector(state => state.user);
   const estimate = useSelector(state => state.estimate);
 
   useEffect(() => {
-    const selectedTarget = {
-      minAge,
-      maxAge,
-      gender,
-      country: selectedCountry
-    };
+    const selectedTarget = { ...targetData };
 
     for (const key in selectedTarget) {
       if (!selectedTarget[key]) {
@@ -38,7 +35,7 @@ export default function CreateCampaign() {
     }
 
     dispatch(getEstimate(selectedTarget));
-  }, [selectedCountry, minAge, maxAge, gender]);
+  }, [targetData]);
 
   async function handleNewCampaignFormSubmit(data) {
     const IMP = window.IMP;
@@ -47,8 +44,11 @@ export default function CreateCampaign() {
     const campaignDuration = differenceInCalendarDays(parseISO(data.expiresAt), new Date());
 
     try {
-      console.log(selectedCountry)
-      const response = await fetchNewCampaign({ ...data, content: url, country: selectedCountry, minAge, maxAge, gender, dailyBudget });
+      const response = await fetchNewCampaign({
+        ...data,
+        ...targetData,
+        content: url,
+      });
       const responseBody = await response.json();
 
       if (!response.ok) {
@@ -63,7 +63,7 @@ export default function CreateCampaign() {
         pay_method: 'card',
         merchant_uid: merchantId,
         name: data.title,
-        amount: dailyBudget * campaignDuration,
+        amount: targetData.dailyBudget * campaignDuration,
         buyer_email: user.email,
         buyer_name: user.name,
       }, async (rsp) => {
@@ -87,11 +87,11 @@ export default function CreateCampaign() {
     }
   }
 
-  async function handleImageUpload(e) {
-    e.preventDefault();
+  async function handleImageUpload(event) {
+    event.preventDefault();
 
     const data = new FormData();
-    const file = e.target.image.files[0];
+    const file = event.target.image.files[0];
 
     if (!file) {
       dispatch(errorOccured('파일이 존재하지 않습니다.'));
@@ -122,14 +122,10 @@ export default function CreateCampaign() {
       <CampaignForm
         estimate={estimate}
         imageUrl={url}
+        targetData={targetData}
+        setTargetData={setTargetData}
         onImageUpload={handleImageUpload}
         onFormSubmit={handleNewCampaignFormSubmit}
-        onCountrySelect={setSelectedCountry}
-        setMinAge={setMinAge}
-        setMaxAge={setMaxAge}
-        setGender={setGender}
-        setDailyBudget={setDailyBudget}
-        dailyBudget={dailyBudget}
       />
     </S.Container>
   );

--- a/src/pages/CreateCampaign/index.jsx
+++ b/src/pages/CreateCampaign/index.jsx
@@ -1,15 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import { parseISO, differenceInCalendarDays } from 'date-fns';
 import { useSelector, useDispatch } from 'react-redux';
 
 import { CreateCampaign as S } from './styles';
 import Header from '../../components/Header';
 import CampaignForm from '../../components/CampaignForm';
+import { requestPay } from '../../utils/requestPay';
 import { checkFileSize } from '../../utils/index';
 import { errorOccured } from '../../reducers/error';
 import { getEstimate } from '../../reducers/estimate';
 import { fetchImageFile } from '../../apis/image';
-import { fetchPaymentResult } from '../../apis/payment';
 import { fetchNewCampaign } from '../../apis/campaigns';
 
 export default function CreateCampaign() {
@@ -21,9 +20,9 @@ export default function CreateCampaign() {
     country: null,
     dailyBudget: '5000',
   });
-  const dispatch = useDispatch();
   const user = useSelector(state => state.user);
   const estimate = useSelector(state => state.estimate);
+  const dispatch = useDispatch();
 
   useEffect(() => {
     const selectedTarget = { ...targetData };
@@ -38,11 +37,6 @@ export default function CreateCampaign() {
   }, [targetData]);
 
   async function handleNewCampaignFormSubmit(data) {
-    const IMP = window.IMP;
-    IMP.init(process.env.REACT_APP_IMPORT_ID);
-
-    const campaignDuration = differenceInCalendarDays(parseISO(data.expiresAt), new Date());
-
     try {
       const response = await fetchNewCampaign({
         ...data,
@@ -50,38 +44,21 @@ export default function CreateCampaign() {
         content: url,
       });
       const responseBody = await response.json();
+      const { merchantId } = responseBody.data;
 
       if (!response.ok) {
         dispatch(errorOccured('캠페인 생성에 실패했습니다.'));
         return;
       }
 
-      const { merchantId } = responseBody.data;
-
-      IMP.request_pay({
-        pg: 'html5_inicis',
-        pay_method: 'card',
-        merchant_uid: merchantId,
-        name: data.title,
-        amount: targetData.dailyBudget * campaignDuration,
-        buyer_email: user.email,
-        buyer_name: user.name,
-      }, async (rsp) => {
-        if (rsp.success) {
-          const { imp_uid, merchant_uid } = rsp;
-          const response = await fetchPaymentResult({ imp_uid, merchant_uid });
-
-          if (!response.ok) {
-            dispatch(errorOccured('결제에 실패했습니다.'));
-            return;
-          }
-
-          dispatch(errorOccured('캠페인 생성이 완료되었습니다.', '/dashboard'));
-        } else {
-          dispatch(errorOccured('결제에 실패했습니다.'));
-          return;
-        }
-      });
+      requestPay({
+        merchantId,
+        title: data.title,
+        dailyBudget: targetData.dailyBudget,
+        expiresAt: data.expiresAt,
+        userEmail: user.email,
+        userName: user.name,
+      }, '/dashboard', dispatch);
     } catch (err) {
       dispatch(errorOccured('캠페인 생성에 실패했습니다.'));
     }

--- a/src/pages/CreateCampaign/index.jsx
+++ b/src/pages/CreateCampaign/index.jsx
@@ -10,6 +10,7 @@ import { errorOccured } from '../../reducers/error';
 import { getEstimate } from '../../reducers/estimate';
 import { fetchImageFile } from '../../apis/image';
 import { fetchNewCampaign } from '../../apis/campaigns';
+import { campaignMessage, imageUploadMessage } from '../../constants/message';
 
 export default function CreateCampaign() {
   const [url, setUrl] = useState('');
@@ -47,7 +48,7 @@ export default function CreateCampaign() {
       const { merchantId } = responseBody.data;
 
       if (!response.ok) {
-        dispatch(errorOccured('캠페인 생성에 실패했습니다.'));
+        dispatch(errorOccured(campaignMessage.CAMPAIGN_CREATION_FAILED));
         return;
       }
 
@@ -60,7 +61,7 @@ export default function CreateCampaign() {
         userName: user.name,
       }, '/dashboard', dispatch);
     } catch (err) {
-      dispatch(errorOccured('캠페인 생성에 실패했습니다.'));
+      dispatch(errorOccured(campaignMessage.CAMPAIGN_CREATION_FAILED));
     }
   }
 
@@ -71,12 +72,12 @@ export default function CreateCampaign() {
     const file = event.target.image.files[0];
 
     if (!file) {
-      dispatch(errorOccured('파일이 존재하지 않습니다.'));
+      dispatch(errorOccured(imageUploadMessage.FILE_NOT_EXIST));
       return;
     }
 
     if (!checkFileSize(file)) {
-      dispatch(errorOccured('파일이 최대 크기(150KB)를 초과하였습니다.'));
+      dispatch(errorOccured(imageUploadMessage.MAXIMIM_FILE_SIZE_EXCEEDED));
       return;
     }
 
@@ -89,7 +90,7 @@ export default function CreateCampaign() {
 
       setUrl(url);
     } catch (error) {
-      dispatch(errorOccured('파일 업로드에 실패하였습니다.'));
+      dispatch(errorOccured(imageUploadMessage.FILE_UPLOAD_FAILED));
     }
   }
 

--- a/src/pages/CreateCampaign/index.jsx
+++ b/src/pages/CreateCampaign/index.jsx
@@ -6,14 +6,14 @@ import Header from '../../components/Header';
 import CampaignForm from '../../components/CampaignForm';
 import { requestPay } from '../../utils/requestPay';
 import { checkFileSize } from '../../utils/index';
-import { errorOccured } from '../../reducers/error';
+import { errorOccurred } from '../../reducers/error';
 import { getEstimate } from '../../reducers/estimate';
 import { fetchImageFile } from '../../apis/image';
 import { fetchNewCampaign } from '../../apis/campaigns';
 import { campaignMessage, imageUploadMessage } from '../../constants/message';
 
 export default function CreateCampaign() {
-  const [url, setUrl] = useState('');
+  const [imageUrl, setImageUrl] = useState('');
   const [targetData, setTargetData] = useState({
     minAge: null,
     maxAge: null,
@@ -42,13 +42,13 @@ export default function CreateCampaign() {
       const response = await fetchNewCampaign({
         ...data,
         ...targetData,
-        content: url,
+        content: imageUrl,
       });
       const responseBody = await response.json();
       const { merchantId } = responseBody.data;
 
       if (!response.ok) {
-        dispatch(errorOccured(campaignMessage.CAMPAIGN_CREATION_FAILED));
+        dispatch(errorOccurred(campaignMessage.CAMPAIGN_CREATION_FAILED));
         return;
       }
 
@@ -61,7 +61,7 @@ export default function CreateCampaign() {
         userName: user.name,
       }, '/dashboard', dispatch);
     } catch (err) {
-      dispatch(errorOccured(campaignMessage.CAMPAIGN_CREATION_FAILED));
+      dispatch(errorOccurred(campaignMessage.CAMPAIGN_CREATION_FAILED));
     }
   }
 
@@ -72,12 +72,12 @@ export default function CreateCampaign() {
     const file = event.target.image.files[0];
 
     if (!file) {
-      dispatch(errorOccured(imageUploadMessage.FILE_NOT_EXIST));
+      dispatch(errorOccurred(imageUploadMessage.FILE_NOT_EXIST));
       return;
     }
 
     if (!checkFileSize(file)) {
-      dispatch(errorOccured(imageUploadMessage.MAXIMIM_FILE_SIZE_EXCEEDED));
+      dispatch(errorOccurred(imageUploadMessage.MAXIMIM_FILE_SIZE_EXCEEDED));
       return;
     }
 
@@ -86,11 +86,11 @@ export default function CreateCampaign() {
     try {
       const response = await fetchImageFile(data);
       const responseBody = await response.json();
-      const url = responseBody.data.url;
+      const { url } = responseBody.data;
 
-      setUrl(url);
+      setImageUrl(url);
     } catch (error) {
-      dispatch(errorOccured(imageUploadMessage.FILE_UPLOAD_FAILED));
+      dispatch(errorOccurred(imageUploadMessage.FILE_UPLOAD_FAILED));
     }
   }
 
@@ -99,7 +99,7 @@ export default function CreateCampaign() {
       <Header />
       <CampaignForm
         estimate={estimate}
-        imageUrl={url}
+        imageUrl={imageUrl}
         targetData={targetData}
         setTargetData={setTargetData}
         onImageUpload={handleImageUpload}

--- a/src/pages/Register/index.jsx
+++ b/src/pages/Register/index.jsx
@@ -4,7 +4,7 @@ import { useHistory } from 'react-router-dom';
 
 import SplitLayout from '../../components/SplitLayout';
 import RegisterForm from '../../components/RegisterForm';
-import { errorOccured } from '../../reducers/error';
+import { errorOccurred } from '../../reducers/error';
 import { saveRegistrationData } from '../../apis/register';
 import { registerMessage } from '../../constants/message';
 
@@ -18,13 +18,13 @@ export default function Register() {
       const { message } = await response.json();
 
       if (!response.ok) {
-        dispatch(errorOccured(message));
+        dispatch(errorOccurred(message));
         return;
       }
 
       history.push('/login');
     } catch (error) {
-      dispatch(errorOccured(registerMessage.SIGN_UP_FAILED));
+      dispatch(errorOccurred(registerMessage.SIGN_UP_FAILED));
     }
   }
 

--- a/src/pages/Register/index.jsx
+++ b/src/pages/Register/index.jsx
@@ -6,6 +6,7 @@ import SplitLayout from '../../components/SplitLayout';
 import RegisterForm from '../../components/RegisterForm';
 import { errorOccured } from '../../reducers/error';
 import { saveRegistrationData } from '../../apis/register';
+import { registerMessage } from '../../constants/message';
 
 export default function Register() {
   const dispatch = useDispatch();
@@ -23,7 +24,7 @@ export default function Register() {
 
       history.push('/login');
     } catch (error) {
-      dispatch(errorOccured('회원가입에 실패했습니다.'));
+      dispatch(errorOccured(registerMessage.SIGN_UP_FAILED));
     }
   }
 

--- a/src/reducers/error.js
+++ b/src/reducers/error.js
@@ -1,8 +1,8 @@
-const ERROR_OCCURED = 'ERROR_OCCURED';
+const ERROR_OCCURRED = 'ERROR_OCCURRED';
 const ERROR_SETTLED = 'ERROR_SETTLED';
 
-export const errorOccured = (message, link) => ({
-  type: ERROR_OCCURED,
+export const errorOccurred = (message, link) => ({
+  type: ERROR_OCCURRED,
   payload: {
     message,
     link,
@@ -21,7 +21,7 @@ const initialState = {
 
 export default function reducer(state = initialState, action) {
   switch (action.type) {
-    case ERROR_OCCURED: {
+    case ERROR_OCCURRED: {
       return {
         ...state,
         display: true,

--- a/src/utils/requestPay.js
+++ b/src/utils/requestPay.js
@@ -2,6 +2,7 @@ import { parseISO, differenceInCalendarDays } from 'date-fns';
 
 import { errorOccured } from '../reducers/error';
 import { fetchPaymentResult } from '../apis/payment';
+import { paymentMessage } from '../constants/message';
 
 export const requestPay = async (info, link, dispatch) => {
   const {
@@ -32,17 +33,17 @@ export const requestPay = async (info, link, dispatch) => {
         const response = await fetchPaymentResult({ imp_uid, merchant_uid });
 
         if (!response.ok) {
-          dispatch(errorOccured('결제에 실패했습니다.'));
+          dispatch(errorOccured(paymentMessage.PAYMENT_FAILED));
           return;
         }
 
-        dispatch(errorOccured('결제가 완료되었습니다.', link));
+        dispatch(errorOccured(paymentMessage.PAYMENT_SUCCESS, link));
       } else {
-        dispatch(errorOccured('결제에 실패했습니다.'));
+        dispatch(errorOccured(paymentMessage.PAYMENT_FAILED));
         return;
       }
     });
   } catch (error) {
-    dispatch(errorOccured('캠페인 생성에 실패했습니다.'));
+    dispatch(errorOccured(paymentMessage.PAYMENT_FAILED));
   }
 };

--- a/src/utils/requestPay.js
+++ b/src/utils/requestPay.js
@@ -1,0 +1,48 @@
+import { parseISO, differenceInCalendarDays } from 'date-fns';
+
+import { errorOccured } from '../reducers/error';
+import { fetchPaymentResult } from '../apis/payment';
+
+export const requestPay = async (info, link, dispatch) => {
+  const {
+    merchantId,
+    title,
+    dailyBudget,
+    expiresAt,
+    userEmail,
+    userName,
+  } = info;
+  const campaignDuration = differenceInCalendarDays(parseISO(expiresAt), new Date());
+
+  const IMP = window.IMP;
+  IMP.init(process.env.REACT_APP_IMPORT_ID);
+
+  try {
+    IMP.request_pay({
+      pg: 'html5_inicis',
+      pay_method: 'card',
+      merchant_uid: merchantId,
+      name: title,
+      amount: dailyBudget * campaignDuration,
+      buyer_email: userEmail,
+      buyer_name: userName,
+    }, async (rsp) => {
+      if (rsp.success) {
+        const { imp_uid, merchant_uid } = rsp;
+        const response = await fetchPaymentResult({ imp_uid, merchant_uid });
+
+        if (!response.ok) {
+          dispatch(errorOccured('결제에 실패했습니다.'));
+          return;
+        }
+
+        dispatch(errorOccured('결제가 완료되었습니다.', link));
+      } else {
+        dispatch(errorOccured('결제에 실패했습니다.'));
+        return;
+      }
+    });
+  } catch (error) {
+    dispatch(errorOccured('캠페인 생성에 실패했습니다.'));
+  }
+};

--- a/src/utils/requestPay.js
+++ b/src/utils/requestPay.js
@@ -1,6 +1,6 @@
 import { parseISO, differenceInCalendarDays } from 'date-fns';
 
-import { errorOccured } from '../reducers/error';
+import { errorOccurred } from '../reducers/error';
 import { fetchPaymentResult } from '../apis/payment';
 import { paymentMessage } from '../constants/message';
 
@@ -33,17 +33,17 @@ export const requestPay = async (info, link, dispatch) => {
         const response = await fetchPaymentResult({ imp_uid, merchant_uid });
 
         if (!response.ok) {
-          dispatch(errorOccured(paymentMessage.PAYMENT_FAILED));
+          dispatch(errorOccurred(paymentMessage.PAYMENT_FAILED));
           return;
         }
 
-        dispatch(errorOccured(paymentMessage.PAYMENT_SUCCESS, link));
+        dispatch(errorOccurred(paymentMessage.PAYMENT_SUCCESS, link));
       } else {
-        dispatch(errorOccured(paymentMessage.PAYMENT_FAILED));
+        dispatch(errorOccurred(paymentMessage.PAYMENT_FAILED));
         return;
       }
     });
   } catch (error) {
-    dispatch(errorOccured(paymentMessage.PAYMENT_FAILED));
+    dispatch(errorOccurred(paymentMessage.PAYMENT_FAILED));
   }
 };


### PR DESCRIPTION
- 캠페인 타겟 설정과 관련된 여러개의 state들을 targetData라는 이름의 state로 관리하도록 수정
- CreateCampaign page, DashboardMain component에서 중복되어 사용되던 결제관련 로직을 requestPay라는 util 함수로 빼줌
- Modal에 띄워질 error 메시지들을 상수로 빼줌
- 코드 네이밍 수정